### PR TITLE
Add logging and snippet capture for proof-of-work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 ## Pathos de Mathos
+
+This repository provides a simple script to search mathematics papers on
+arXiv and locate lines beginning with the word "Obviously". To prove that the
+scraper actually processes each paper, it writes a log file containing a small
+random snippet from every article it scans.
+
+Run the unit tests with:
+
+```bash
+python -m unittest
+```

--- a/find_obviously.py
+++ b/find_obviously.py
@@ -1,0 +1,95 @@
+import re
+from dataclasses import dataclass
+from typing import List, Iterable, Optional, TextIO
+import random
+
+try:
+    import arxiv  # type: ignore
+    import requests
+    from pdfminer.high_level import extract_text
+except Exception:  # pragma: no cover - optional deps
+    arxiv = None  # type: ignore
+    extract_text = None
+    requests = None
+
+
+@dataclass
+class ObviouslyMatch:
+    title: str
+    authors: List[str]
+    line: str
+
+
+def scan_text_for_obviously(text: str) -> List[str]:
+    """Return lines that start with 'Obviously'."""
+    pattern = re.compile(r"^\s*Obviously\b", re.IGNORECASE)
+    return [line for line in text.splitlines() if pattern.search(line)]
+
+
+def extract_random_snippet(text: str, length: int = 80) -> str:
+    """Return a random snippet from the given text."""
+    text = text.replace("\n", " ").strip()
+    if len(text) <= length:
+        return text
+    start = random.randint(0, len(text) - length)
+    return text[start : start + length]
+
+
+def scan_text(
+    text: str,
+    title: str,
+    authors: List[str],
+    log_file: Optional[TextIO] = None,
+) -> Iterable[ObviouslyMatch]:
+    """Scan the text for matches and optionally log a snippet."""
+    if log_file:
+        snippet = extract_random_snippet(text, 60)
+        log_file.write(f"{title} | {snippet}\n")
+    for line in scan_text_for_obviously(text):
+        yield ObviouslyMatch(title, authors, line)
+
+
+def search_and_scan(
+    query: str, max_results: int = 50, log_path: Optional[str] = None
+) -> Iterable[ObviouslyMatch]:
+    """Search arXiv and yield matches where a line starts with 'Obviously'.
+
+    Parameters
+    ----------
+    query:
+        arXiv query string.
+    max_results:
+        maximum number of results to fetch.
+    log_path:
+        optional path to a log file where proof-of-work information is written.
+    """
+    if arxiv is None or extract_text is None or requests is None:
+        raise RuntimeError("Required packages are not installed")
+
+    log_file: Optional[TextIO]
+    if log_path:
+        log_file = open(log_path, "w", encoding="utf-8")
+    else:
+        log_file = None
+
+    try:
+        search = arxiv.Search(query=query, max_results=max_results)
+        for result in search.results():
+            pdf_url = result.pdf_url
+            resp = requests.get(pdf_url, timeout=10)
+            resp.raise_for_status()
+            text = extract_text(resp.content)
+            yield from scan_text(
+                text, result.title, [a.name for a in result.authors], log_file
+            )
+    finally:
+        if log_file:
+            log_file.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    LOG_PATH = "obviously_log.txt"
+    for match in search_and_scan("cat:math", max_results=5, log_path=LOG_PATH):
+        print(f"{match.title} - {', '.join(match.authors)}")
+        print(f"\t{match.line}")
+    print(f"Log written to {LOG_PATH}")

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,48 @@
+import unittest
+import random
+from io import StringIO
+
+from find_obviously import (
+    scan_text_for_obviously,
+    extract_random_snippet,
+    scan_text,
+)
+
+
+class TestScan(unittest.TestCase):
+    def test_scan_finds_lines(self):
+        text = (
+            "Obviously this is a test.\n"
+            "not obviously here.\n"
+            "\tObviously we start with whitespace.\n"
+            "This is not the droid.\n"
+            "OBVIOUSLY capitals count.\n"
+        )
+        lines = scan_text_for_obviously(text)
+        self.assertEqual(len(lines), 3)
+        self.assertIn("Obviously this is a test.", lines)
+        self.assertIn("\tObviously we start with whitespace.", lines)
+        self.assertIn("OBVIOUSLY capitals count.", lines)
+
+    def test_extract_random_snippet_deterministic(self):
+        text = "1234567890" * 10  # 100 chars
+        random.seed(0)
+        snippet = extract_random_snippet(text, 10)
+        random.seed(0)
+        snippet2 = extract_random_snippet(text, 10)
+        self.assertEqual(snippet, snippet2)
+        self.assertEqual(len(snippet), 10)
+
+    def test_scan_text_logs_snippet(self):
+        text = "foo bar baz\nObviously line here.\nmore text"
+        random.seed(1)
+        log = StringIO()
+        matches = list(scan_text(text, "Title", ["Author"], log))
+        self.assertEqual(len(matches), 1)
+        log_content = log.getvalue()
+        self.assertIn("Title", log_content)
+        self.assertTrue(len(log_content.strip()) > 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- log random snippets from each scanned paper for proof-of-work
- expose `scan_text` and `extract_random_snippet`
- update CLI example to write `obviously_log.txt`
- expand README with instructions
- extend unit tests for logging behavior

## Testing
- `python -m unittest`
